### PR TITLE
Remove Materializer constraint from AkkaStreamCursor.*Source api.

### DIFF
--- a/.ci_scripts/validate.sh
+++ b/.ci_scripts/validate.sh
@@ -18,6 +18,8 @@ git diff --exit-code || (
   false
 )
 
+sbt ++$TRAVIS_SCALA_VERSION ";error ;mimaReportBinaryIssues" || exit 2
+
 # Sonatype staging (avoid Central sync delay)
 perl -pe "s|resolvers |resolvers in ThisBuild += \"Sonatype Staging\" at \"https://oss.sonatype.org/content/repositories/staging/\"\n\r\nresolvers |" < "$SCRIPT_DIR/../build.sbt" > /tmp/build.sbt && mv /tmp/build.sbt "$SCRIPT_DIR/../build.sbt"
 


### PR DESCRIPTION
Instead use the execution context provided when the source is "run",
ie. via the GraphStage api.

This make the api more useful for cases were you don't have a Materializer at hand, and match akka-stream users expectation that `Source`s are "blue prints" and the `Materializer` in only needed/provided via the `run`* methods.