### PR TITLE
Complete the materialized value of akka-stream Sources only on stage completion.

### DIFF
--- a/akka-stream/src/main/mima-filters/0.12.0.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/0.12.0.backwards.excludes
@@ -1,0 +1,6 @@
+# Package private changes:
+ProblemFilters.exclude[MissingTypesProblem]("reactivemongo.akkastream.DocumentStage")
+ProblemFilters.exclude[DirectMissingMethodProblem]("reactivemongo.akkastream.DocumentStage.createLogic")
+ProblemFilters.exclude[DirectMissingMethodProblem]("reactivemongo.akkastream.State.materialized")
+ProblemFilters.exclude[MissingTypesProblem]("reactivemongo.akkastream.ResponseStage")
+ProblemFilters.exclude[DirectMissingMethodProblem]("reactivemongo.akkastream.ResponseStage.createLogic")

--- a/akka-stream/src/main/scala/FutureFlattenSource.scala
+++ b/akka-stream/src/main/scala/FutureFlattenSource.scala
@@ -1,0 +1,111 @@
+package reactivemongo.akkastream
+
+import akka.stream.{ Attributes, Graph, Outlet, SourceShape }
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }
+
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.util.Try
+
+/* Backported from akka 2.5: to be removed in favour of Source.fromFutureSource when akka 2.4 support is dropped*/
+private final class ReactiveMongoFlattenSource[T, M](
+    futureSource: Future[Graph[SourceShape[T], M]])
+  extends GraphStageWithMaterializedValue[SourceShape[T], Future[M]] {
+
+  val out: Outlet[T] = Outlet("ReactiveMongoFlattenSource.out")
+  override val shape = SourceShape(out)
+
+  override def initialAttributes = Attributes.name("reactiveMongoFlattenSource")
+
+  override def createLogicAndMaterializedValue(attr: Attributes): (GraphStageLogic, Future[M]) = {
+    val materialized = Promise[M]()
+
+    val logic = new GraphStageLogic(shape) with InHandler with OutHandler {
+      private val sinkIn = new SubSinkInlet[T]("ReactiveMongoFlattenSource.in")
+
+      override def preStart(): Unit =
+        futureSource.value match {
+          case Some(it) ⇒
+            // this optimisation avoids going through any execution context, in similar vein to FastFuture
+            onFutureSourceCompleted(it)
+          case _ ⇒
+            val cb = getAsyncCallback[Try[Graph[SourceShape[T], M]]](onFutureSourceCompleted).invoke _
+            futureSource.onComplete(cb)(sameThreadExecutionContext) // could be optimised FastFuture-like
+        }
+
+      // initial handler (until future completes)
+      setHandler(out, new OutHandler {
+        def onPull(): Unit = {}
+
+        override def onDownstreamFinish(): Unit = {
+          if (!materialized.isCompleted) {
+            // make sure we always yield the matval if possible, even if downstream cancelled
+            // before the source was materialized
+            val matValFuture = futureSource.map { gr ⇒
+              // downstream finish means it cancelled, so we push that signal through into the future materialized source
+              Source.fromGraph(gr).to(Sink.cancelled)
+                .withAttributes(attr)
+                .run()(subFusingMaterializer)
+            }(sameThreadExecutionContext)
+            materialized.completeWith(matValFuture)
+          }
+
+          super.onDownstreamFinish()
+        }
+      })
+
+      def onPush(): Unit =
+        push(out, sinkIn.grab())
+
+      def onPull(): Unit =
+        sinkIn.pull()
+
+      override def onUpstreamFinish(): Unit =
+        completeStage()
+
+      override def postStop(): Unit =
+        if (!sinkIn.isClosed) sinkIn.cancel()
+
+      def onFutureSourceCompleted(result: Try[Graph[SourceShape[T], M]]): Unit = {
+        result.map { graph ⇒
+          val runnable = Source.fromGraph(graph).toMat(sinkIn.sink)(Keep.left)
+          val matVal = subFusingMaterializer.materialize(runnable)
+          materialized.success(matVal)
+
+          setHandler(out, this)
+          sinkIn.setHandler(this)
+
+          if (isAvailable(out)) {
+            sinkIn.pull()
+          }
+
+        }.failed.foreach { t ⇒
+          sinkIn.cancel()
+          materialized.failure(t)
+          failStage(t)
+        }
+      }
+    }
+
+    (logic, materialized.future)
+  }
+
+  override def toString: String = "ReactiveMongoFlattenSource"
+}
+
+private[akkastream] object ReactiveMongoFlattenSource {
+  def apply[T, M](futureSource: Future[Graph[SourceShape[T], M]]) = Source.fromGraph(new ReactiveMongoFlattenSource(futureSource))
+}
+
+/**
+ * WARNING: Not A General Purpose ExecutionContext!
+ *
+ * This is an execution context which runs everything on the calling thread.
+ * It is very useful for actions which are known to be non-blocking and
+ * non-throwing in order to save a round-trip to the thread pool.
+ */
+private object sameThreadExecutionContext extends ExecutionContext {
+  override def execute(runnable: Runnable): Unit = runnable.run()
+  override def reportFailure(t: Throwable): Unit =
+    throw new IllegalStateException("exception in sameThreadExecutionContext", t)
+}

--- a/akka-stream/src/main/scala/package.scala
+++ b/akka-stream/src/main/scala/package.scala
@@ -1,7 +1,7 @@
 package reactivemongo
 
 import scala.concurrent.Future
-import reactivemongo.api.{ Cursor, CursorProducer, CursorOps }
+import reactivemongo.api.{ Cursor, CursorOps, CursorProducer }
 
 package object akkastream {
   /** Provides Akka Streams instances for CursorProducer typeclass. */

--- a/akka-stream/src/test/scala/CursorSpec.scala
+++ b/akka-stream/src/test/scala/CursorSpec.scala
@@ -1,6 +1,8 @@
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
+import reactivemongo.akkastream.State
+
 import scala.util.{ Failure, Try }
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
@@ -425,8 +427,11 @@ class CursorSpec extends org.specs2.mutable.Specification with CursorFixtures {
               (count + 1L) -> (n + i)
           }
 
-          src.runWith(consume) must beEqualTo(
-            nDocs.toLong -> 136397386L
+          src.toMat(consume)((state, res) => state.flatMap(s => res.map((s, _)))).run() must beEqualTo(
+            (
+              State.Successful(nDocs.toLong),
+              nDocs.toLong -> 136397386L
+            )
           ).await(1, moreTime)
         }
       }


### PR DESCRIPTION
This allows users to properly order clean-up of resources.